### PR TITLE
fix args.multiprocessing_distributed bug.

### DIFF
--- a/fixmatch.py
+++ b/fixmatch.py
@@ -181,7 +181,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -199,7 +199,7 @@ def main_worker(gpu, ngpus_per_node, args):
         lb_dset = image_loader.get_lb_train_data()
         ulb_dset = image_loader.get_ulb_train_data()
         eval_dset = image_loader.get_lb_test_data()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
                             
     loader_dict = {}

--- a/flexmatch.py
+++ b/flexmatch.py
@@ -181,7 +181,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -198,7 +198,7 @@ def main_worker(gpu, ngpus_per_node, args):
         lb_dset = image_loader.get_lb_train_data()
         ulb_dset = image_loader.get_ulb_train_data()
         eval_dset = image_loader.get_lb_test_data()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     

--- a/fullysupervised.py
+++ b/fullysupervised.py
@@ -175,7 +175,7 @@ def main_worker(gpu, ngpus_per_node, args):
 
     cudnn.benchmark = True
 
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
     # Construct Dataset & DataLoader
     train_dset = SSL_Dataset(args, alg='fullysupervised', name=args.dataset, train=True,
@@ -185,7 +185,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='fullysupervised', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
     
 

--- a/meanteacher.py
+++ b/meanteacher.py
@@ -177,7 +177,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -188,7 +188,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='meanteacher', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/mixmatch.py
+++ b/mixmatch.py
@@ -176,7 +176,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -187,7 +187,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='mixmatch', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/pimodel.py
+++ b/pimodel.py
@@ -176,7 +176,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -187,7 +187,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='pimodel', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/pseudolabel.py
+++ b/pseudolabel.py
@@ -176,7 +176,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -187,7 +187,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='pseudolabel', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/remixmatch.py
+++ b/remixmatch.py
@@ -182,7 +182,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -193,7 +193,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='remixmatch', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/uda.py
+++ b/uda.py
@@ -177,7 +177,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -188,7 +188,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='uda', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}

--- a/vat.py
+++ b/vat.py
@@ -176,7 +176,7 @@ def main_worker(gpu, ngpus_per_node, args):
     logger.info(f"Arguments: {args}")
 
     cudnn.benchmark = True
-    if args.rank != 0:
+    if args.rank != 0 and args.distributed:
         torch.distributed.barrier()
  
     # Construct Dataset & DataLoader
@@ -187,7 +187,7 @@ def main_worker(gpu, ngpus_per_node, args):
     _eval_dset = SSL_Dataset(args, alg='vat', name=args.dataset, train=False,
                              num_classes=args.num_classes, data_dir=args.data_dir)
     eval_dset = _eval_dset.get_dset()
-    if args.rank == 0:
+    if args.rank == 0 and args.distributed:
         torch.distributed.barrier()
  
     loader_dict = {}


### PR DESCRIPTION
Hi, thanks for this awesome framework!

I have encountered some errors when I try to disable multi-processing distributed training by setting ```args.multiprocessing_distributed``` to False. Liked in issue #16 

I found out the errors are due to the command ```torch.distributed.barrier()```, which shouldn't be executed when ```args.multiprocessing_distributed``` is disable. So I added a condition on the if statement, to make sure ```torch.distributed.barrier()``` will only  be executed when ```args.distributed``` is Ture. This fixes my problem.