### PR TITLE
fix bug in gradient clipping

### DIFF
--- a/models/fixmatch/fixmatch.py
+++ b/models/fixmatch/fixmatch.py
@@ -162,6 +162,7 @@ class FixMatch:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/flexmatch/flexmatch.py
+++ b/models/flexmatch/flexmatch.py
@@ -186,6 +186,7 @@ class FlexMatch:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/fullysupervised/fullysupervised.py
+++ b/models/fullysupervised/fullysupervised.py
@@ -116,6 +116,7 @@ class FullySupervised:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/meanteacher/meanteacher.py
+++ b/models/meanteacher/meanteacher.py
@@ -138,6 +138,7 @@ class MeanTeacher:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/mixmatch/mixmatch.py
+++ b/models/mixmatch/mixmatch.py
@@ -173,6 +173,7 @@ class MixMatch:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/pimodel/pimodel.py
+++ b/models/pimodel/pimodel.py
@@ -130,6 +130,7 @@ class PiModel:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/pseudolabel/pseudolabel.py
+++ b/models/pseudolabel/pseudolabel.py
@@ -142,6 +142,7 @@ class PseudoLabel:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/remixmatch/remixmatch.py
+++ b/models/remixmatch/remixmatch.py
@@ -219,6 +219,7 @@ class ReMixMatch:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/uda/uda.py
+++ b/models/uda/uda.py
@@ -165,6 +165,7 @@ class Uda:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()

--- a/models/vat/vat.py
+++ b/models/vat/vat.py
@@ -125,6 +125,7 @@ class Vat:
             if args.amp:
                 scaler.scale(total_loss).backward()
                 if (args.clip > 0):
+                    scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), args.clip)
                 scaler.step(self.optimizer)
                 scaler.update()


### PR DESCRIPTION
In automatic mixed precision, we should unscale all gradients before clip them.
ref: [https://pytorch.org/docs/stable/notes/amp_examples.html](url)